### PR TITLE
Fix scrolling tune list on mobile

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,11 +11,13 @@ import Overview from "./ui/overview/overview";
 import { registerServiceWorker } from "./services/service-worker";
 import { library } from '@fortawesome/fontawesome-svg-core'
 import { faCaretDown, faCheck, faClock, faCode, faCog, faCopy, faDownload, faEraser, faExclamationCircle, faInfoCircle, faFileExport, faFileImport, faHandPointRight, faHeadphones, faMobileAlt, faMusic, faPause, faPen, faPencilAlt, faPlay, faPlayCircle, faPlus, faQuestionCircle, faShare, faSlidersH, faStar, faStop, faTrash, faVolumeMute, faWindowClose } from '@fortawesome/free-solid-svg-icons'
+import { tryFindDraggableTarget } from './ui/utils/dragdrop';
 
 registerServiceWorker();
 
 polyfill({
-    dragImageTranslateOverride: scrollBehaviourDragImageTranslateOverride
+	dragImageTranslateOverride: scrollBehaviourDragImageTranslateOverride,
+	tryFindDraggableTarget: tryFindDraggableTarget
 });
 
 Vue.use(BootstrapVue);

--- a/src/ui/listen/listen.vue
+++ b/src/ui/listen/listen.vue
@@ -1,5 +1,5 @@
 <div class="bb-listen">
-	<div class="bb-listen-tunes" v-touch:start="handleTouchStart" v-touch:moving="handleTouchMove" v-touch:end="handleTouchEnd" ref="tunes">
+	<div class="bb-listen-tunes no-drag" v-touch:start="handleTouchStart" v-touch:moving="handleTouchMove" v-touch:end="handleTouchEnd" ref="tunes">
 		<PatternListFilter v-model="filter" :show-custom="false" />
 
 		<hr />

--- a/src/ui/utils/dragdrop.ts
+++ b/src/ui/utils/dragdrop.ts
@@ -1,0 +1,18 @@
+export function tryFindDraggableTarget(event: TouchEvent) {
+	let el = event.target as HTMLElement;
+	if (el.closest('.no-drag')) {
+		return;
+	}
+	do {
+		if (el.draggable === false) {
+			continue;
+		}
+		if (el.draggable === true) {
+			return el;
+		}
+		if (el.getAttribute
+			&& el.getAttribute('draggable') === 'true') {
+			return el;
+		}
+	} while ((el = el.parentNode as HTMLElement) && el !== document.body);
+}


### PR DESCRIPTION
There is a problem with scrolling the tune list on mobile devices (tested with Chrome and Firefox on Android 12). Unless you manage to start the scrolling motion from an area outside or between the links, it does not scroll and all and instead tries to drag the link.

It turns out that the use of [mobile-drag-drop](https://github.com/timruffles/mobile-drag-drop) is causing this problem. Specifically, the [`tryFindDraggableTarget`](https://github.com/timruffles/mobile-drag-drop/blob/bff08f4/src/internal/drag-utils.ts#L8) function tries to find the closest ancestor that has `draggable` set to `true`. The problem is, `a` elements have this attribute set to true by default. Browsers know their way around this, but the polyfill doesn't.

To fix this, I have overriden the `tryFindDraggableTarget` function to ignore any ancestors that have the `no-drag` class. Then I added this class to the `.bb-listen-tunes` element. It's not the cleanest solution, but it's localized. I didn't want to change the drag&drop behavior in other places.