### PR TITLE
update hardcore to amsterdam/tnm24 version

### DIFF
--- a/src/defaultTunes.ts
+++ b/src/defaultTunes.ts
@@ -242,24 +242,20 @@ const rawTunes: {[tuneName: string]: RawTune} = {
 				sh: '@re',
 				ot: '                                                          E D   '
 			},
-			'Hard Core Break': {
-				ls: repeat(2, '              XXX             XXX             XXX       XXXXXXXX') + repeat(2, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),
+			'Hardcore Break': {
+				ls: repeat(2, '              XXX             XXX             XXX       XXXXXXXX') +
+					repeat(1, 'X   X   X   X XXX   X   X   X XXX   X   X   X XXX   X   XXXXXXXX') +
+					repeat(1, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),
 				ms: '@ls',
 				hs: '@ls',
-				re: repeat(1, '              XXX             XXX             XXX       XXXXXXXX') + repeat(3, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),
+				re: repeat(1, '              XXX             XXX             XXX       XXXXXXXX') + 
+					repeat(1, 'X   X   X   X XXX   X   X   X XXX   X   X   X XXX   X   XXXXXXXX') +
+					repeat(2, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),
 				sn: '@re',
 				ta: '@re',
-				ag: repeat(3, 'o o o o o o o ooo o o o o o o ooo o o o o o o ooo o o o oooooooo') + repeat(1, 'a a a a a a a aaa a a a a a a aaa a a a a a a aaa a a a aaaaaaaa'),
+				ag: repeat(3, 'o o o o o o o ooo o o o o o o ooo o o o o o o ooo o o o oooooooo') + 
+					repeat(1, 'a a a a a a a aaa a a a a a a aaa a a a a a a aaa a a a aaaaaaaa'),
 				sh: '@re',
-				volumeHack: {
-					ls: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
-					ms: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
-					hs: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
-					re: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
-					sn: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
-					ta: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
-					sh: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 }
-				}
 			},
 			'Nellie the Elephant Break': {
 				ls: '            X X             X X             X X XX XX XX XX X X XX XX XX XX X X XX XX XX XX X X ' + repeat(2, '                ') + repeat(3, 'X  X  X         ') + 'X           XXX ',

--- a/src/defaultTunes.ts
+++ b/src/defaultTunes.ts
@@ -242,7 +242,8 @@ const rawTunes: {[tuneName: string]: RawTune} = {
 				sh: '@re',
 				ot: '                                                          E D   '
 			},
-			'Hardcore Break': {
+			'Hard Core Break': {
+				displayName: "Hardcore Break",
 				ls: repeat(2, '              XXX             XXX             XXX       XXXXXXXX') +
 					repeat(1, 'X   X   X   X XXX   X   X   X XXX   X   X   X XXX   X   XXXXXXXX') +
 					repeat(1, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),

--- a/src/defaultTunes.ts
+++ b/src/defaultTunes.ts
@@ -242,7 +242,7 @@ const rawTunes: {[tuneName: string]: RawTune} = {
 				sh: '@re',
 				ot: '                                                          E D   '
 			},
-			'Hard Core Break': {
+			'Hardcore Break': {
 				displayName: "Hardcore Break",
 				ls: repeat(2, '              XXX             XXX             XXX       XXXXXXXX') +
 					repeat(1, 'X   X   X   X XXX   X   X   X XXX   X   X   X XXX   X   XXXXXXXX') +
@@ -257,6 +257,26 @@ const rawTunes: {[tuneName: string]: RawTune} = {
 				ag: repeat(3, 'o o o o o o o ooo o o o o o o ooo o o o o o o ooo o o o oooooooo') + 
 					repeat(1, 'a a a a a a a aaa a a a a a a aaa a a a a a a aaa a a a aaaaaaaa'),
 				sh: '@re',
+			},
+			'Hard Core Break': {
+				displayName: "Hardcore Break (original)",
+				ls: repeat(2, '              XXX             XXX             XXX       XXXXXXXX') + repeat(2, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),
+				ms: '@ls',
+				hs: '@ls',
+				re: repeat(1, '              XXX             XXX             XXX       XXXXXXXX') + repeat(3, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),
+				sn: '@re',
+				ta: '@re',
+				ag: repeat(3, 'o o o o o o o ooo o o o o o o ooo o o o o o o ooo o o o oooooooo') + repeat(1, 'a a a a a a a aaa a a a a a a aaa a a a a a a aaa a a a aaaaaaaa'),
+				sh: '@re',
+				volumeHack: {
+					ls: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
+					ms: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
+					hs: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
+					re: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
+					sn: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
+					ta: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 },
+					sh: { 66:  .3, 78:  1, 82:  .3, 94:  1, 98:  .3, 110: 1, 114: .3, 120: 1, 130: .6, 142: 1, 146: .6, 158: 1, 162: .6, 174: 1, 178: .6, 184: 1 }
+				}
 			},
 			'Nellie the Elephant Break': {
 				ls: '            X X             X X             X X XX XX XX XX X X XX XX XX XX X X XX XX XX XX X X ' + repeat(2, '                ') + repeat(3, 'X  X  X         ') + 'X           XXX ',

--- a/src/defaultTunes.ts
+++ b/src/defaultTunes.ts
@@ -243,7 +243,6 @@ const rawTunes: {[tuneName: string]: RawTune} = {
 				ot: '                                                          E D   '
 			},
 			'Hardcore Break': {
-				displayName: "Hardcore Break",
 				ls: repeat(2, '              XXX             XXX             XXX       XXXXXXXX') +
 					repeat(1, 'X   X   X   X XXX   X   X   X XXX   X   X   X XXX   X   XXXXXXXX') +
 					repeat(1, 'X X X X X X X XXX X X X X X X XXX X X X X X X XXX X X X XXXXXXXX'),


### PR DESCRIPTION
### Hardcore break update

At TNM 24, we had a workshop to discuss some variants of the hardcore break. We decided to introduce this "Amsterdam" version (which in turn was inspired by Lille's version) to everyone. I believe it really caught on - with everyone playing this version at the TNM. So, I would propose we update it in the player and sheets (will make a PR for that also). 

Alternatively, we could also add it as a new special break. IMO both versions are so similar that it's not very helpful to have two versions "alive" at the same time, so I opted to replace it for now.

### Technical

- I updated and tested (with local server) the notes of the hardcore break in defaultTunes.ts
- I removed the "VolumeHack". I don't think this version of the break needs a change in volume - and I also couldn't hear any volume changes in the original one. But maybe this is needed or it does something else? I'm not sure, happy to learn!

### Spelling?

Should it be hardcore (the music genre) instead of hard core (like the core of a group)?