### PR TITLE
Hafla/Hook Break: Fix first response

### DIFF
--- a/src/defaultTunes.ts
+++ b/src/defaultTunes.ts
@@ -1439,7 +1439,7 @@ const rawTunes: {[tuneName: string]: RawTune} = {
 				ls: 'X X     X       X       X X     X   X   X   X   X       X       ',
 				ms: '@ls',
 				hs: '@ls',
-				re: '   XXX    XXX XX  XXXXX     X XX  XX  XX  XX  XX  X   X     X   ',
+				re: '    XXX   XXX XX  XXXXX     X XX  XX  XX  XX  XX  X   X     X   ',
 				sn: '@re',
 				ta: '@re',
 				ag: '@re',


### PR DESCRIPTION
Moving the first response one unit to the right makes it sound a lot better to me and also greatly improves playability.

I don't know the original authors or their intentions but I'm pretty sure that was a mistake in transcribing the tune.