### PR TITLE
Fix modal closing and history loss on tune creation

### DIFF
--- a/src/services/history.ts
+++ b/src/services/history.ts
@@ -48,7 +48,10 @@ export class History {
 			));
 
 			watch(() => Number(this._storage.bbState) && this._storage[`bbState-${this._storage.bbState}`], () => {
-				this.loadHistoricState(Number(this._storage.bbState));
+				const key = Number(this._storage.bbState);
+				if (key !== this.currentKey.value) {
+					this.loadHistoricState(key);
+				}
 			}, { deep: true, immediate: true });
 
 			watch(this._compressedState, () => {


### PR DESCRIPTION
Fixes #146

## Summary

- **Bug A**: When editing a custom tune's pattern, the editor dialog closes unexpectedly. The storage watcher in `History` triggers `loadHistoricState()` after every `saveCurrentState()` call, creating a feedback loop that can replace the entire `state.value` object and disrupt the modal lifecycle.
- **Bug B**: Previously created custom tunes disappear from the current state after creating or editing another tune. The state replacement from the same feedback loop can cause data loss, requiring users to navigate back through history to recover their tunes.

**Fix**: Add a guard in the storage watcher to skip `loadHistoricState()` when the key matches `currentKey.value` (just saved by `saveCurrentState()`). This breaks the feedback loop while preserving the intended behavior for initial load, cross-tab sync, and manual history navigation.

**Changed file**: `src/services/history.ts` (3 lines added, 1 removed)

## Test plan

- [ ] Create a new tune, open pattern editor, edit strokes → dialog stays open
- [ ] Create multiple tunes, refresh page → all tunes persist
- [ ] Import a shared link → state loads correctly
- [ ] Navigate history (when available) → historical states load correctly
- [ ] Use the app in two tabs → cross-tab sync still works